### PR TITLE
Respond to system theme on iOS

### DIFF
--- a/ios/Classes/SwiftFlutterInteractiveKeyboardPlugin.swift
+++ b/ios/Classes/SwiftFlutterInteractiveKeyboardPlugin.swift
@@ -140,7 +140,11 @@ public class SwiftFlutterInteractiveKeyboardPlugin: NSObject, FlutterPlugin {
             keyboardOpen = false
         }
         keyboardBackground.frame = CGRect(x: 0, y: UIScreen.main.bounds.size.height -  (isKeyboardShowing ? keyboardRect.size.height : 0), width: keyboardRect.size.width, height: keyboardRect.size.height)
-        keyboardBackground.backgroundColor = .white
+        if #available(iOS 12.0, *) {
+            keyboardBackground.backgroundColor = firstResponder.traitCollection.userInterfaceStyle == .dark ? .black : .white
+        } else {
+            keyboardBackground.backgroundColor = .white
+        }
         keyboardView.isHidden = isKeyboardShowing
         if(UIView.areAnimationsEnabled) {
             keyboardView.isHidden = true


### PR DESCRIPTION
- Changes keyboard color depending on system theme

Possible enhancements
- Could also take in a parameter for the `showKeyboard` method that allows for a dev to provide the desired keyboard color
- I didn't test with Android to see if this feature should also be implemented there