### PR TITLE
Update platform specification in pubspec

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,5 +17,9 @@ dev_dependencies:
 
 flutter:
   plugin:
-    androidPackage: com.ujiboo.flutter_interactive_keyboard
-    pluginClass: FlutterInteractiveKeyboardPlugin
+    platforms:
+      android:
+        package: com.ujiboo.flutter_interactive_keyboard
+        pluginClass: FlutterInteractiveKeyboardPlugin
+      ios:
+        pluginClass: FlutterInteractiveKeyboardPlugin

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: flutter_interactive_keyboard
 description: A flutter plugin to dismiss the keyboard interactively similar to the IOS native behavior. On Android the functionality is mimed without drag.
 version: 0.2.0
-author: Mattia Crovero <mcrovero@gmail.com>
 homepage: https://github.com/mcrovero/flutter_interactive_keyboard
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
+  flutter: ">=1.12.0"
 
 dependencies:
   flutter:


### PR DESCRIPTION
- Updates the specification of supported platforms per https://flutter.dev/docs/development/packages-and-plugins/developing-packages#plugin-platforms
- Removes `author` because
> Your pubspec.yaml includes an "author" section which is no longer used and may be removed.